### PR TITLE
Fix tools reference layout on starter branch

### DIFF
--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -26,6 +26,6 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:padding="16dp"
-        tools:listitem="@layout/word_item_view" />
+        tools:listitem="@layout/item_view" />
 
 </FrameLayout>


### PR DESCRIPTION
We were having a reference issue with the layout file representing an item.
![image](https://user-images.githubusercontent.com/49538805/130538423-e9991575-a76d-4987-aecf-f00f11b98ed5.png)
The correct name is `item_view` and not `word_item_view`.