### PR TITLE
Bump versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-kapt'
     id 'androidx.navigation.safeargs.kotlin'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,18 +16,16 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-kapt'
     id 'androidx.navigation.safeargs.kotlin'
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.example.wordsapp"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -55,7 +53,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "com.google.android.material:material:$material_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Words">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        appcompat_version = "1.4.1"
-        constraintlayout_version = "2.1.3"
-        core_ktx_version = "1.7.0"
-        kotlin_version = "1.6.10"
-        material_version = "1.6.0-alpha03"
-        nav_version = '2.4.1'
+        appcompat_version = "1.4.2"
+        constraintlayout_version = "2.1.4"
+        core_ktx_version = "1.8.0"
+        kotlin_version = "1.7.0"
+        material_version = "1.7.0-alpha02"
+        nav_version = '2.4.2'
         lifecycle_version = "2.4.0"
         datastore_version = "1.0.0"
     }
@@ -30,7 +30,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,21 +16,21 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        appcompat_version = "1.2.0"
-        constraintlayout_version = "2.0.2"
-        core_ktx_version = "1.3.2"
-        kotlin_version = "1.5.30"
-        material_version = "1.2.1"
-        nav_version = "2.3.1"
-        lifecycle_version = "2.3.1"
+        appcompat_version = "1.4.1"
+        constraintlayout_version = "2.1.3"
+        core_ktx_version = "1.7.0"
+        kotlin_version = "1.6.10"
+        material_version = "1.6.0-alpha03"
+        nav_version = '2.4.1'
+        lifecycle_version = "2.4.0"
         datastore_version = "1.0.0"
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 
@@ -42,7 +42,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip


### PR DESCRIPTION
Updated:
Kotlin version
 Gradle and AGP versions
 SDK versions
libraries numbers versions
Lines removed:
 implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
jcenter() replaced with mavenCentral()
android:exported="true" set up in Manifest