### PR TITLE
Bump versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.4.0'
-    androidTestImplementation 'androidx.navigation:navigation-testing:2.4.1'
+    androidTestImplementation 'androidx.navigation:navigation-testing:2.4.2'
 
     debugImplementation 'androidx.fragment:fragment-testing:1.4.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,13 +21,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.example.wordsapp"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 
@@ -55,18 +54,17 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "com.google.android.material:material:$material_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.2'
-    androidTestImplementation 'androidx.navigation:navigation-testing:2.3.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.4.0'
+    androidTestImplementation 'androidx.navigation:navigation-testing:2.4.1'
 
-    debugImplementation 'androidx.fragment:fragment-testing:1.3.6'
+    debugImplementation 'androidx.fragment:fragment-testing:1.4.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Words">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        appcompat_version = "1.3.1"
-        constraintlayout_version = "2.1.1"
-        core_ktx_version = "1.3.2"
-        kotlin_version = "1.5.31"
-        material_version = "1.4.0"
-        nav_version = "2.3.5"
-        lifecycle_version = "2.3.1"
+        appcompat_version = "1.4.1"
+        constraintlayout_version = "2.1.3"
+        core_ktx_version = "1.7.0"
+        kotlin_version = "1.6.10"
+        material_version = "1.6.0-alpha03"
+        nav_version = "2.4.1"
+        lifecycle_version = "2.4.1"
         datastore_version = "1.0.0"
     }
     repositories {
@@ -30,7 +30,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         appcompat_version = "1.4.1"
         constraintlayout_version = "2.1.3"
         core_ktx_version = "1.8.0"
-        kotlin_version = "1.6.21"
+        kotlin_version = "1.7.0"
         material_version = "1.7.0-alpha02"
         nav_version = "2.4.2"
         lifecycle_version = "2.4.1"

--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,10 @@ buildscript {
     ext {
         appcompat_version = "1.4.1"
         constraintlayout_version = "2.1.3"
-        core_ktx_version = "1.7.0"
-        kotlin_version = "1.6.10"
-        material_version = "1.6.0-alpha03"
-        nav_version = "2.4.1"
+        core_ktx_version = "1.8.0"
+        kotlin_version = "1.6.21"
+        material_version = "1.7.0-alpha02"
+        nav_version = "2.4.2"
         lifecycle_version = "2.4.1"
         datastore_version = "1.0.0"
     }
@@ -30,7 +30,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip


### PR DESCRIPTION
Updated:
Kotlin version
Gradle and AGP versions
SDK versions
libraries numbers versions

buildToolsVersion "30.0.3" line removed
implementation "org.jetbrains.kotlin:kotlin-stdlib..." line removed

android:exported="true" set up in Manifest